### PR TITLE
Test podman

### DIFF
--- a/configure_network.sh
+++ b/configure_network.sh
@@ -7,7 +7,7 @@ RESPONSE=`/usr/lib/besu-23.4.1/bin/besu operator generate-blockchain-config --co
 
 ./copyKeys.sh
 
-./bootnode.sh --CONTAINER_NAME="boot_node" --HOST
+./bootnode.sh --CONTAINER_NAME="boot_node"
 
 sshpass -p "${NODE2_PWD}" scp -r Node-2 genesis.json .env.production "${NODE2}:${NODE2_DIR}"
 sshpass -p "${NODE3_PWD}" scp -r Node-3 genesis.json .env.production "${NODE3}:${NODE3_DIR}"

--- a/configure_network.sh
+++ b/configure_network.sh
@@ -3,7 +3,13 @@
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/.env.network
 
-RESPONSE=`/usr/lib/besu-23.4.1/bin/besu operator generate-blockchain-config --config-file=ibftConfigFile.json --to=networkFiles --private-key-file-name=key`
+BESU_EXECUTABLE="besu"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  BESU_EXECUTABLE="/usr/lib/besu-23.4.1/bin/besu"
+fi
+
+RESPONSE=`${BESU_EXECUTABLE} operator generate-blockchain-config --config-file=ibftConfigFile.json --to=networkFiles --private-key-file-name=key`
 
 ./copyKeys.sh
 

--- a/node.sh
+++ b/node.sh
@@ -10,7 +10,7 @@ P2P_PORT=30303
 
 ENV_PATH=${__dir}/.env.production
 
-HOST=false
+LOCAL=false
 
 # parse command-line arguments
 for arg in "$@"
@@ -31,8 +31,8 @@ do
         --P2P_PORT=*)
         P2P_PORT="${arg#*=}"
         ;;
-        --HOST)
-        HOST=true
+        --LOCAL)
+        LOCAL=true
         ;;
         --help)
         # Display script usage
@@ -43,7 +43,7 @@ do
         echo "  --RPC_HTTP_PORT=VALUE      Specify the local port number for HTTP JSON-RPC (default: 8545)"
         echo "  --RPC_WS_PORT=VALUE        Specify the local port number for WS JSON-RPC (default: 8546)"
         echo "  --RPC_HTTP_PORT=VALUE      Specify the local port number for P2P (default: 30303)"
-        echo "  --HOST                     Run docker container has host network"
+        echo "  --LOCAL                    Run nodes in local network"
         exit 0
         ;;
         *)
@@ -58,7 +58,7 @@ do
         echo "  --RPC_HTTP_PORT=VALUE      Specify the local port number for HTTP JSON-RPC (default: 8545)"
         echo "  --RPC_WS_PORT=VALUE        Specify the local port number for WS JSON-RPC (default: 8546)"
         echo "  --RPC_HTTP_PORT=VALUE      Specify the local port number for P2P (default: 30303)"
-        echo "  --HOST                     Run docker container has host network"
+        echo "  --LOCAL                    Run nodes in local network"
         exit 0
         # ignore unrecognized arguments
         ;;
@@ -87,20 +87,20 @@ fi
 CMD_DOCKER_CREATE="docker create --name ${CONTAINER_NAME} \
     -p ${RPC_HTTP_PORT}:${RPC_HTTP_PORT} \
     -p ${RPC_WS_PORT}:${RPC_WS_PORT} \
-    -p ${P2P_PORT}:${P2P_PORT} "
-
-if [ "${HOST}" = true ]; then
-  CMD_DOCKER_CREATE+="--net host "
-fi
+    -p ${P2P_PORT}:${P2P_PORT} \
+    -p ${P2P_PORT}:${P2P_PORT}/udp "
 
 CMD_DOCKER_CREATE+="${BESU_IMAGE} \
     --genesis-file=/genesis.json \
     --rpc-http-enabled \
     --rpc-http-api=ETH,NET,IBFT \
     --rpc-http-cors-origins="all" \
+    --rpc-http-port=${RPC_HTTP_PORT}
     --rpc-ws-enabled \
     --rpc-ws-host=0.0.0.0 \
+    --rpc-ws-port=${RPC_WS_PORT} \
     --rpc-ws-apis=ADMIN,ETH,MINER,WEB3,NET,PRIV,EEA \
+    --p2p-port=${P2P_PORT} \
     --host-allowlist="*" \
     --bootnodes=${BOOT_NODE_ENODE} \
     --min-gas-price=0"

--- a/node.sh
+++ b/node.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NODE_NAME="Node"
 CONTAINER_NAME="Node"
@@ -11,6 +12,11 @@ P2P_PORT=30303
 ENV_PATH=${__dir}/.env.production
 
 LOCAL=false
+USE_PODMAN=false
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  USE_PODMAN=true # use podman as default for os x
+fi
 
 # parse command-line arguments
 for arg in "$@"
@@ -34,6 +40,9 @@ do
         --LOCAL)
         LOCAL=true
         ;;
+        --PODMAN)
+        USE_PODMAN=true
+        ;;
         --help)
         # Display script usage
         echo "Usage: ./node.sh [OPTIONS]"
@@ -44,6 +53,7 @@ do
         echo "  --RPC_WS_PORT=VALUE        Specify the local port number for WS JSON-RPC (default: 8546)"
         echo "  --RPC_HTTP_PORT=VALUE      Specify the local port number for P2P (default: 30303)"
         echo "  --LOCAL                    Run nodes in local network"
+        echo "  --PODMAN                   Use podman as container engine"
         exit 0
         ;;
         *)
@@ -59,11 +69,18 @@ do
         echo "  --RPC_WS_PORT=VALUE        Specify the local port number for WS JSON-RPC (default: 8546)"
         echo "  --RPC_HTTP_PORT=VALUE      Specify the local port number for P2P (default: 30303)"
         echo "  --LOCAL                    Run nodes in local network"
+        echo "  --PODMAN                   Use podman as container engine"
         exit 0
         # ignore unrecognized arguments
         ;;
     esac
 done
+
+if [ "$USE_PODMAN" = true ]; then
+  function docker() {
+    podman "$@"
+  }
+fi
 
 source ${ENV_PATH}
 

--- a/reset.sh
+++ b/reset.sh
@@ -4,6 +4,12 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_PATH=${__dir}/.env.defaults
 source ${ENV_PATH}
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  function docker() {
+    podman "$@" 
+  }
+fi
+
 read -r -p "Are you sure want to reset config? [y/n]" response
 case "$response" in
     [yY][eE][sS]|[yY])

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-RESPONSE=`besu operator generate-blockchain-config --config-file=ibftConfigFile.json --to=networkFiles --private-key-file-name=key`
+BESU_EXECUTABLE="besu"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  BESU_EXECUTABLE="/usr/lib/besu-23.4.1/bin/besu"
+fi
+
+RESPONSE=`${BESU_EXECUTABLE} operator generate-blockchain-config --config-file=ibftConfigFile.json --to=networkFiles --private-key-file-name=key`
 
 ./copyKeys.sh
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -4,8 +4,8 @@ RESPONSE=`besu operator generate-blockchain-config --config-file=ibftConfigFile.
 
 ./copyKeys.sh
 
-./bootnode.sh --CONTAINER_NAME="boot_node" --NODE_NAME=Node-1
+./bootnode.sh --CONTAINER_NAME="boot_node" --NODE_NAME=Node-1 --LOCAL
 
-./node.sh --CONTAINER_NAME="Node-2" --NODE_NAME=Node-2 --RPC_HTTP_PORT=8555 --RPC_WS_PORT=8556 --P2P_PORT=30313
-./node.sh --CONTAINER_NAME="Node-3" --NODE_NAME=Node-3 --RPC_HTTP_PORT=8565 --RPC_WS_PORT=8566 --P2P_PORT=30323
-./node.sh --CONTAINER_NAME="Node-4" --NODE_NAME=Node-4 --RPC_HTTP_PORT=8575 --RPC_WS_PORT=8576 --P2P_PORT=30333
+./node.sh --CONTAINER_NAME="Node-2" --NODE_NAME=Node-2 --RPC_HTTP_PORT=8555 --RPC_WS_PORT=8556 --P2P_PORT=30313 --LOCAL
+./node.sh --CONTAINER_NAME="Node-3" --NODE_NAME=Node-3 --RPC_HTTP_PORT=8565 --RPC_WS_PORT=8566 --P2P_PORT=30323 --LOCAL
+./node.sh --CONTAINER_NAME="Node-4" --NODE_NAME=Node-4 --RPC_HTTP_PORT=8575 --RPC_WS_PORT=8576 --P2P_PORT=30333 --LOCAL


### PR DESCRIPTION
- host mode 없이 동작하도록 변경:
  p2p 포트를 tcp, udp 모두 개방

- 기존에 포트포워딩만 적용되고 besu에서 해당 포트 사용하도록 되어있지 않은 부분 수정:
  --rpc-http-port, --rpc-ws-port, --p2p-port 옵션 추가 적용

- 스크립트에서 host 옵션 대신 local 옵션을 적용하도록 변경

- podman 사용 가능하도록 수정
  OS X: default로 podman 사용 가정
  linux: USE_PODMAN 옵션 추가